### PR TITLE
Parallelize Inference over Multiple Inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,10 @@ python -m LASErMPNN.run_batch_inference -h
 This script is useful to generate multiple designs for one or multiple inputs. Creates an output directory with subdirectories for each input file (unless run with a single input file).
 
 ```text
-usage: run_batch_inference.py [-h] [--designs_per_batch DESIGNS_PER_BATCH] [--model_weights_path MODEL_WEIGHTS_PATH] [--sequence_temp SEQUENCE_TEMP] [--first_shell_sequence_temp FIRST_SHELL_SEQUENCE_TEMP] [--chi_temp CHI_TEMP] [--chi_min_p CHI_MIN_P] [--seq_min_p SEQ_MIN_P] [--device INFERENCE_DEVICE] [--use_water] [--silent]
-                              [--ignore_key_mismatch] [--disabled_residues DISABLED_RESIDUES] [--fix_beta] [--repack_only_input_sequence] [--ignore_ligand] [--budget_residue_sele_string BUDGET_RESIDUE_SELE_STRING] [--ala_budget ALA_BUDGET] [--gly_budget GLY_BUDGET] [--noncanonical_aa_ligand] [--fs_calc_ca_distance FS_CALC_CA_DISTANCE]
-                              [--fs_calc_burial_hull_alpha_value FS_CALC_BURIAL_HULL_ALPHA_VALUE] [--fs_no_calc_burial] [--disable_charged_fs]
+usage: run_batch_inference.py [-h] [--designs_per_batch DESIGNS_PER_BATCH] [--inputs_processed_simultaneously INPUTS_PROCESSED_SIMULTANEOUSLY] [--model_weights_path MODEL_WEIGHTS_PATH] [--sequence_temp SEQUENCE_TEMP]
+                              [--first_shell_sequence_temp FIRST_SHELL_SEQUENCE_TEMP] [--chi_temp CHI_TEMP] [--chi_min_p CHI_MIN_P] [--seq_min_p SEQ_MIN_P] [--device INFERENCE_DEVICE] [--use_water] [--silent] [--ignore_key_mismatch]
+                              [--disabled_residues DISABLED_RESIDUES] [--fix_beta] [--repack_only_input_sequence] [--ignore_ligand] [--budget_residue_sele_string BUDGET_RESIDUE_SELE_STRING] [--ala_budget ALA_BUDGET] [--gly_budget GLY_BUDGET]
+                              [--noncanonical_aa_ligand] [--fs_calc_ca_distance FS_CALC_CA_DISTANCE] [--fs_calc_burial_hull_alpha_value FS_CALC_BURIAL_HULL_ALPHA_VALUE] [--fs_no_calc_burial] [--disable_charged_fs]
                               input_pdb_directory output_pdb_directory designs_per_input
 
 Run batch LASErMPNN inference.
@@ -111,6 +112,8 @@ options:
   -h, --help            show this help message and exit
   --designs_per_batch DESIGNS_PER_BATCH, -b DESIGNS_PER_BATCH
                         Number of designs to generate per batch. If designs_per_input > designs_per_batch, chunks up the inference calls in batches of this size. Default is 30, can increase/decrease depending on available GPU memory.
+  --inputs_processed_simultaneously INPUTS_PROCESSED_SIMULTANEOUSLY, -n INPUTS_PROCESSED_SIMULTANEOUSLY
+                        When passed a list of multiple files, this is the number of input files to process per pass through the GPU. Useful when generating a few sequences for many input files.
   --model_weights_path MODEL_WEIGHTS_PATH, -w MODEL_WEIGHTS_PATH
                         Path to model weights. Default: /nfs/polizzi/bfry/programs/LASErMPNN/model_weights/laser_weights_0p1A_noise_ligandmpnn_split.pt
   --sequence_temp SEQUENCE_TEMP

--- a/run_batch_inference.py
+++ b/run_batch_inference.py
@@ -265,7 +265,7 @@ def parse_args(default_weights_path: os.PathLike):
     parser.add_argument('output_pdb_directory', type=str, help='Path to directory to output LASErMPNN designs.')
     parser.add_argument('designs_per_input', type=int, help='Number of designs to generate per input.')
     parser.add_argument('--designs_per_batch', '-b', type=int, default=30, help='Number of designs to generate per batch. If designs_per_input > designs_per_batch, chunks up the inference calls in batches of this size. Default is 30, can increase/decrease depending on available GPU memory.')
-    parser.add_argument('--inputs_processed_simultaneously', type=int, default=5, help='When passed a list of multiple files, this is the number of input files to process per pass through the GPU. Useful when generating a few sequences for many input files.')
+    parser.add_argument('--inputs_processed_simultaneously', '-n', type=int, default=5, help='When passed a list of multiple files, this is the number of input files to process per pass through the GPU. Useful when generating a few sequences for many input files.')
     parser.add_argument('--model_weights_path', '-w', type=str, default=f'{default_weights_path}', help=f'Path to model weights. Default: {default_weights_path}')
 
     parser.add_argument('--sequence_temp', type=float, default=None, help='Temperature for sequence sampling.')

--- a/run_batch_inference.py
+++ b/run_batch_inference.py
@@ -6,6 +6,7 @@ Once model is trained, this script can be used to run inference on a directory o
 Benjamin Fry (bfry@g.harvard.edu)
 """
 import os
+import re
 import argparse
 from typing import *
 from pathlib import Path
@@ -22,8 +23,66 @@ from LASErMPNN.run_inference import get_protein_hierview, load_model_from_parame
 CURR_FILE_DIR_PATH = Path(__file__).parent
 
 
+def parse_int_chunks_or_string(s):
+    """
+    Parses the input string and returns a tuple of integers if any integer chunks are found; 
+    otherwise, returns the original string.
+    Args:
+        s (str): The input string to parse.
+    Returns:
+        tuple[int] or str: A tuple of integers extracted from the string if any are found,
+        otherwise the original string.
+    """
+    try:
+        ints = re.findall(r'\d+', s)
+        if ints:
+            return tuple(map(int, ints))
+        else:
+            return s
+    except:
+        return s # Just in case.
+
+
+def collate_batch_data(input_list: List[BatchData]) -> BatchData:
+
+    index_offset = 0
+    ligand_info_output = None
+    for batch in input_list:
+        new_index_offset = batch.batch_indices.max() + 1
+        batch.batch_indices += index_offset
+        if batch.unprocessed_ligand_input_data is not None:
+            batch.unprocessed_ligand_input_data.lig_batch_indices += index_offset
+            if ligand_info_output is None:
+                ligand_info_output = batch.unprocessed_ligand_input_data
+            else:
+                ligand_info_output = ligand_info_output.extend(batch.unprocessed_ligand_input_data)
+        index_offset += new_index_offset
+
+    batch_data_dict = {
+        'pdb_codes': [pdb_code for batch in input_list for pdb_code in batch.pdb_codes],
+        'sequence_indices': torch.cat([batch.sequence_indices for batch in input_list]),
+        'chi_angles': torch.cat([batch.chi_angles for batch in input_list]),
+        'backbone_coords': torch.cat([batch.backbone_coords for batch in input_list]),
+        'phi_psi_angles': torch.cat([batch.phi_psi_angles for batch in input_list]),
+        'sidechain_contact_number': torch.cat([batch.sidechain_contact_number for batch in input_list]),
+        'residue_burial_counts': torch.cat([batch.residue_burial_counts for batch in input_list]), 
+        'batch_indices': torch.cat([batch.batch_indices for batch in input_list]),
+        'chain_indices': torch.cat([batch.chain_indices for batch in input_list]),
+        'sampled_chain_mask': torch.cat([batch.sampled_chain_mask for batch in input_list]),
+        'resnum_indices': torch.cat([batch.resnum_indices for batch in input_list]),
+        'chain_mask': torch.cat([batch.chain_mask for batch in input_list]),
+        'extra_atom_contact_mask': torch.cat([batch.extra_atom_contact_mask for batch in input_list]),
+        'msa_data': torch.cat([batch.msa_data for batch in input_list]),
+        'msa_depth_weight': torch.cat([batch.msa_depth_weight for batch in input_list]),
+        'unprocessed_ligand_input_data': ligand_info_output,
+        'first_shell_ligand_contact_mask': torch.cat([batch.first_shell_ligand_contact_mask for batch in input_list]),
+        'sc_mediated_hbond_counts': torch.cat([batch.sc_mediated_hbond_counts for batch in input_list]),
+    }
+    return BatchData(**batch_data_dict)
+
+
 def _run_inference(
-    model, params: dict, input_file_path: Union[str, pr.HierView], designs_per_input: int, 
+    model, params: dict, input_file: Union[os.PathLike, pr.HierView, Sequence[os.PathLike]], designs_per_input: int, 
     sequence_temp: Optional[float] = None, chi_temp: Optional[float] = None, 
     chi_min_p: float = 0.0, seq_min_p: float = 0.0, use_water: bool = False, disable_pbar: bool = False,
     ignore_chain_mask_zeros: bool = False, disabled_residues_list: List[str] = ['X'], bb_noise: float = 0.0,
@@ -37,42 +96,55 @@ def _run_inference(
     model.eval()
 
     # Load the model and run inference.
-    if isinstance(input_file_path, str): 
-        protein_hv = get_protein_hierview(input_file_path)
-        data = ProteinComplexData(
-            protein_hv, input_file_path, use_input_water=use_water, verbose=not disable_pbar, treat_noncanonical_as_ligand=noncanonical_aa_ligand,
-            first_shell_ca_distance=fs_calc_ca_distance, 
-            first_shell_buried_only=(not fs_no_calc_burial),
-            first_shell_burial_calc_hull_alpha=fs_calc_burial_hull_alpha_value
-        )
+    protein_hvs = []
+    if isinstance(input_file, os.PathLike): 
+        protein_hvs.append(get_protein_hierview(str(input_file)))
+    elif isinstance(input_file, pr.HierView):
+        protein_hvs.append(input_file)
+    elif isinstance(input_file, Iterable) and isinstance(input_file[0], os.PathLike):
+        for path in input_file:
+            protein_hvs.append(get_protein_hierview(str(path)))
     else:
-        protein_hv = input_file_path
+        raise ValueError(f"Unrecognized input_file_path type: {type(input_file)}\n{input_file}")
+
+    data_list = []
+    batch_data_list = []
+    budget_residue_masks = []
+    for protein_hv in protein_hvs:
         data = ProteinComplexData(
-            protein_hv, 'input', use_input_water=use_water, verbose=not disable_pbar, treat_noncanonical_as_ligand=noncanonical_aa_ligand,
-            first_shell_ca_distance=fs_calc_ca_distance, 
+            protein_hv, protein_hv.getAtoms().getTitle(), use_input_water=use_water,
+            verbose=not disable_pbar, treat_noncanonical_as_ligand=noncanonical_aa_ligand,
+            first_shell_ca_distance=fs_calc_ca_distance,
             first_shell_buried_only=(not fs_no_calc_burial),
             first_shell_burial_calc_hull_alpha=fs_calc_burial_hull_alpha_value
         )
 
-    budget_residue_mask = None
-    if budget_residue_sele_string != '' and budget_residue_sele_string is not None:
-        reference_mask_res_indices = protein_hv.getAtoms().select(f"protein and name CA").getResindices()
-        mask_sele_indices = protein_hv.getAtoms().select(f"(same residue as ({budget_residue_sele_string})) and name CA").getResindices()
-        budget_residue_mask = torch.from_numpy(
-            np.isin(reference_mask_res_indices, mask_sele_indices)
-        ).to(model.device).unsqueeze(0).expand(designs_per_input, -1).flatten()
+        budget_residue_mask = None
+        if budget_residue_sele_string != '' and budget_residue_sele_string is not None:
+            reference_mask_res_indices = protein_hv.getAtoms().select(f"protein and name CA").getResindices()
+            mask_sele_indices = protein_hv.getAtoms().select(f"(same residue as ({budget_residue_sele_string})) and name CA").getResindices()
+            budget_residue_mask = torch.from_numpy(
+                np.isin(reference_mask_res_indices, mask_sele_indices)
+            ).to(model.device).unsqueeze(0).expand(designs_per_input, -1).flatten()
+            budget_residue_masks.append(budget_residue_mask)
 
-    batch_data = data.output_batch_data(fix_beta=fix_beta, num_copies=designs_per_input)
+        batch_data = data.output_batch_data(fix_beta=fix_beta, num_copies=designs_per_input)
 
-    if ignore_ligand:
-        batch_data.unprocessed_ligand_input_data.lig_coords = torch.empty(0, 3)
-        batch_data.unprocessed_ligand_input_data.lig_batch_indices = torch.empty(0, dtype=torch.long)
-        batch_data.unprocessed_ligand_input_data.lig_subbatch_indices = torch.empty(0, dtype=torch.long)
-        batch_data.unprocessed_ligand_input_data.lig_burial_maskmask = torch.empty(0, dtype=torch.bool)
-        batch_data.unprocessed_ligand_input_data.lig_atomic_numbers = torch.empty(0, dtype=torch.long)
+        if ignore_ligand:
+            batch_data.unprocessed_ligand_input_data.lig_coords = torch.empty(0, 3)
+            batch_data.unprocessed_ligand_input_data.lig_batch_indices = torch.empty(0, dtype=torch.long)
+            batch_data.unprocessed_ligand_input_data.lig_subbatch_indices = torch.empty(0, dtype=torch.long)
+            batch_data.unprocessed_ligand_input_data.lig_burial_maskmask = torch.empty(0, dtype=torch.bool)
+            batch_data.unprocessed_ligand_input_data.lig_atomic_numbers = torch.empty(0, dtype=torch.long)
 
-    if repack_only_input_sequence:
-        batch_data.chain_mask = torch.ones_like(batch_data.chain_mask)
+        if repack_only_input_sequence:
+            batch_data.chain_mask = torch.ones_like(batch_data.chain_mask)
+
+        data_list.append(data)
+        batch_data_list.append(batch_data)
+
+    budget_residue_mask = torch.cat(budget_residue_masks) if len(budget_residue_masks) > 0 else None
+    batch_data = collate_batch_data(batch_data_list)
 
     # Sample a design
     sampled_output = sample_model(
@@ -90,14 +162,14 @@ def _run_inference(
     full_atom_coords = model.rotamer_builder.cleanup_titratable_hydrogens(
         full_atom_coords.float(), sampled_output.sampled_sequence_indices, nh_coords, batch_data, model.hbond_network_detector
     )
-    # assert isinstance(nh_coords, torch.Tensor), "unreachable."
     sampled_probs = sampled_output.sequence_logits.softmax(dim=-1).gather(1, sampled_output.sampled_sequence_indices.unsqueeze(-1)).squeeze(-1)
-    return sampled_output, full_atom_coords, nh_coords, sampled_probs, batch_data, data
+
+    return sampled_output, full_atom_coords, nh_coords, sampled_probs, batch_data, data_list
 
 
 def run_inference(
         input_pdb_directory, output_pdb_directory, model_weights_path, sequence_temp, chi_temp, 
-        inference_device, designs_per_input, designs_per_batch, use_water, ignore_key_mismatch, 
+        inference_device, designs_per_input, designs_per_batch, inputs_processed_simultaneously, use_water, ignore_key_mismatch, 
         verbose=True, seq_min_p=0.0, chi_min_p=0.0, output_idx_offset=0, disabled_residues='', 
         fix_beta=False, repack_only_input_sequence=False, 
         first_shell_sequence_temp=None, ignore_ligand=False, noncanonical_aa_ligand=False,
@@ -113,41 +185,48 @@ def run_inference(
     model, params = load_model_from_parameter_dict(model_weights_path, inference_device, strict=ignore_key_mismatch)
     model.eval()
 
-    # Loop over all files to design.
-    if verbose:
-        print(f"Processing {input_pdb_directory}:")
-        print(f"Generating {designs_per_input} designs with {model_weights_path} on {inference_device} at temperature {sequence_temp}")
+    input_pdb_directory = Path(input_pdb_directory)
+    output_pdb_directory = Path(output_pdb_directory)
 
     make_subdir = False
-    if os.path.isdir(input_pdb_directory):
-        all_input_files = [os.path.join(input_pdb_directory, x) for x in os.listdir(input_pdb_directory)]
+    if input_pdb_directory.is_dir():
+        all_input_files = [input_pdb_directory / x for x in input_pdb_directory.glob('*.pdb')]
         make_subdir = True
-    elif os.path.exists(input_pdb_directory) and '.pdb' in input_pdb_directory:
+    elif input_pdb_directory.exists() and '.pdb' in input_pdb_directory.name:
         all_input_files = [input_pdb_directory]
-    elif os.path.exists(input_pdb_directory) and input_pdb_directory.endswith('.txt'):
-        all_input_files = [x.strip() for x in open(input_pdb_directory, 'r').readlines() if os.path.exists(x.strip())]
+    elif input_pdb_directory.exists() and input_pdb_directory.suffix == '.txt':
+        all_input_files = [Path(x.strip()) for x in open(input_pdb_directory, 'r').readlines() if Path(x.strip()).exists()]
         make_subdir = True
     else:
         print(f'Could not find {input_pdb_directory}')
-        raise NotImplementedError
+        raise FileNotFoundError
 
-    for file in tqdm([x for x in sorted(all_input_files) if '.pdb' in x]):
+    # Loop over all files to design.
+    all_pdb_files_for_processing = sorted(all_input_files, key=lambda x: parse_int_chunks_or_string(x.stem))
+    if verbose:
+        print(f"Processing {input_pdb_directory}:")
+        print(f"Generating {designs_per_input} designs for {len(all_pdb_files_for_processing)} inputs with {model_weights_path} on {inference_device} at temperature {sequence_temp}")
+
+    input_chunks = np.array_split(all_pdb_files_for_processing, (len(all_pdb_files_for_processing) // inputs_processed_simultaneously) + 1)
+    for files_chunk in tqdm(input_chunks):
         # Make an output subdirectory for each input file.
-        output_subdir_path = output_pdb_directory
-        if not os.path.exists(output_pdb_directory):
-            os.mkdir(output_pdb_directory)
+        output_files_chunk = []
         if make_subdir:
-            output_subdir_path = os.path.join(output_pdb_directory, file.rsplit('/', 1)[-1].split('.')[0])
-            if not os.path.exists(output_subdir_path):
-                os.makedirs(output_subdir_path, exist_ok=True)
+            for file in files_chunk:
+                output_subdir_path = output_pdb_directory / file.stem
+                output_subdir_path.mkdir(exist_ok=True, parents=True)
+                output_files_chunk.append(output_subdir_path)
+        else:
+            output_files_chunk = [output_subdir_path]
+            output_pdb_directory.mkdir(exist_ok=True)
 
         designs_remaining = designs_per_input
         curr_output_idx_offset = output_idx_offset
         while designs_remaining > 0:
             curr_num_to_design = min(designs_per_batch, designs_remaining)
 
-            sampled_output, full_atom_coords, nh_coords, sampled_probs, batch_data, data = _run_inference(
-                model, params, file, curr_num_to_design, 
+            sampled_output, full_atom_coords, nh_coords, sampled_probs, batch_data, data_list = _run_inference(
+                model, params, list(files_chunk), curr_num_to_design, 
                 use_water=use_water, sequence_temp=sequence_temp, chi_temp=chi_temp, chi_min_p=chi_min_p, seq_min_p=seq_min_p, 
                 disabled_residues_list=disabled_residues_list, disable_pbar=not verbose,
                 fix_beta=fix_beta, repack_only_input_sequence=repack_only_input_sequence,
@@ -159,19 +238,23 @@ def run_inference(
                 fs_calc_burial_hull_alpha_value=fs_calc_burial_hull_alpha_value,
                 fs_no_calc_burial=fs_no_calc_burial, disable_charged_fs=disable_charged_fs
             )
-            
-            for idx in range(curr_num_to_design):
-                # Output the current batch design + ligand and write to disk
-                curr_batch_mask = batch_data.batch_indices == idx
-                out_prot = output_protein_structure(full_atom_coords[curr_batch_mask], sampled_output.sampled_sequence_indices[curr_batch_mask], data.residue_identifiers, nh_coords[curr_batch_mask], sampled_probs[curr_batch_mask])
 
-                out_complex = out_prot
-                try:
-                    out_lig = output_ligand_structure(data.ligand_info)
-                    out_complex += out_lig
-                except:
-                    pass
-                pr.writePDB(os.path.join(output_subdir_path, f"design_{idx+curr_output_idx_offset}.pdb"), out_complex)
+            
+            idx_offset = 0
+            for jdx, data in enumerate(data_list):
+                for idx in range(curr_num_to_design):
+                    # Output the current batch design + ligand and write to disk
+                    curr_batch_mask = batch_data.batch_indices == (idx + idx_offset)
+                    out_prot = output_protein_structure(full_atom_coords[curr_batch_mask], sampled_output.sampled_sequence_indices[curr_batch_mask], data.residue_identifiers, nh_coords[curr_batch_mask], sampled_probs[curr_batch_mask])
+
+                    out_complex = out_prot
+                    try:
+                        out_lig = output_ligand_structure(data.ligand_info)
+                        out_complex += out_lig
+                    except:
+                        pass
+                    pr.writePDB(str(output_files_chunk[jdx] / f"design_{idx+curr_output_idx_offset}.pdb"), out_complex)
+                idx_offset += curr_num_to_design
             
             curr_output_idx_offset += curr_num_to_design
             designs_remaining -= curr_num_to_design
@@ -183,6 +266,7 @@ def parse_args(default_weights_path: str):
     parser.add_argument('output_pdb_directory', type=str, help='Path to directory to output LASErMPNN designs.')
     parser.add_argument('designs_per_input', type=int, help='Number of designs to generate per input.')
     parser.add_argument('--designs_per_batch', '-b', type=int, default=30, help='Number of designs to generate per batch. If designs_per_input > designs_per_batch, chunks up the inference calls in batches of this size. Default is 30, can increase/decrease depending on available GPU memory.')
+    parser.add_argument('--inputs_processed_simultaneously', type=int, default=1, help='When passed a list of multiple files, this is the number of input files to process per pass through the GPU. Useful when generating a few sequences for many input files.')
     parser.add_argument('--model_weights_path', '-w', type=str, default=f'{default_weights_path}', help=f'Path to model weights. Default: {default_weights_path}')
 
     parser.add_argument('--sequence_temp', type=float, default=None, help='Temperature for sequence sampling.')

--- a/run_batch_inference.py
+++ b/run_batch_inference.py
@@ -192,7 +192,7 @@ def run_inference(
     if input_pdb_directory.is_dir():
         all_input_files = [input_pdb_directory / x for x in input_pdb_directory.glob('*.pdb')]
         make_subdir = True
-    elif input_pdb_directory.exists() and '.pdb' in input_pdb_directory.name:
+    elif input_pdb_directory.exists() and ('.pdb' in input_pdb_directory.name): # Could be .pdb or .pdb.gz
         all_input_files = [input_pdb_directory]
     elif input_pdb_directory.exists() and input_pdb_directory.suffix == '.txt':
         all_input_files = [Path(x.strip()) for x in open(input_pdb_directory, 'r').readlines() if Path(x.strip()).exists()]
@@ -217,7 +217,7 @@ def run_inference(
                 output_subdir_path.mkdir(exist_ok=True, parents=True)
                 output_files_chunk.append(output_subdir_path)
         else:
-            output_files_chunk = [output_subdir_path]
+            output_files_chunk = [output_pdb_directory]
             output_pdb_directory.mkdir(exist_ok=True)
 
         designs_remaining = designs_per_input
@@ -239,7 +239,6 @@ def run_inference(
                 fs_no_calc_burial=fs_no_calc_burial, disable_charged_fs=disable_charged_fs
             )
 
-            
             idx_offset = 0
             for jdx, data in enumerate(data_list):
                 for idx in range(curr_num_to_design):
@@ -260,13 +259,13 @@ def run_inference(
             designs_remaining -= curr_num_to_design
 
 
-def parse_args(default_weights_path: str):
+def parse_args(default_weights_path: os.PathLike):
     parser = argparse.ArgumentParser(description='Run batch LASErMPNN inference.')
     parser.add_argument('input_pdb_directory', type=str, help='Path to directory of input .pdb or .pdb.gz files, a single input .pdb or .pdb.gz file, or a .txt file of paths to input .pdb or .pdb.gz files.')
     parser.add_argument('output_pdb_directory', type=str, help='Path to directory to output LASErMPNN designs.')
     parser.add_argument('designs_per_input', type=int, help='Number of designs to generate per input.')
     parser.add_argument('--designs_per_batch', '-b', type=int, default=30, help='Number of designs to generate per batch. If designs_per_input > designs_per_batch, chunks up the inference calls in batches of this size. Default is 30, can increase/decrease depending on available GPU memory.')
-    parser.add_argument('--inputs_processed_simultaneously', type=int, default=1, help='When passed a list of multiple files, this is the number of input files to process per pass through the GPU. Useful when generating a few sequences for many input files.')
+    parser.add_argument('--inputs_processed_simultaneously', type=int, default=5, help='When passed a list of multiple files, this is the number of input files to process per pass through the GPU. Useful when generating a few sequences for many input files.')
     parser.add_argument('--model_weights_path', '-w', type=str, default=f'{default_weights_path}', help=f'Path to model weights. Default: {default_weights_path}')
 
     parser.add_argument('--sequence_temp', type=float, default=None, help='Temperature for sequence sampling.')


### PR DESCRIPTION
Implements batching not only to produce multiple sequences per input in parallel as was previously implemented, but implements batching together the inputs themselves significantly accelerating inference for which only a few sequences are being generated for a large number of input backbones.